### PR TITLE
Implemented compress TSs, added Bryton vendor code, added Rider 310 device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+/nbproject


### PR DESCRIPTION
This implements compressed timestamps records, I tested it with my Bryton Rider 310 files (thus the added vendor and devices codes). As far as I can tell there's nothing more to compressed TS than just calculating the timestamp using the given offset and the most recent full timestamp.

Attached is a sample file:

[170316162558.fit.zip](https://github.com/adriangibbons/php-fit-file-analysis/files/860774/170316162558.fit.zip)

